### PR TITLE
Update GitHub token for deployment action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,5 +29,5 @@ jobs:
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.GH_TOKEN_ENTREGA01 }}
+          github_token: ${{ secrets.GH_TOKEN }}
           publish_dir: ./site


### PR DESCRIPTION
Após o retorno de que o deploy não estava ocorrendo como o esperado, foi verificado a questão, o qual apresentou o seguinte diagnóstico:

- Repositório não possuia um Token definido para a automação de deploy do Github Pages, parte essencial para que a automação ocorra.
- Nome definido  para o Token em ".github/workflows/deploy.yml" não condizia com o contexto do repositório.

Nesse sentido, para o primeiro caso, foi gerado o token pelo representante da equipe e anexado ao repositório. Para o segundo caso, foi modificado o nome o qual o Token referenciaria, de modo que este condiza com o nome definido em "Secrets" token definido ao repo.